### PR TITLE
Allow to use the zero value for pid to operate with the current task

### DIFF
--- a/capability/capability.go
+++ b/capability/capability.go
@@ -60,7 +60,8 @@ type Capabilities interface {
 	Apply(kind CapType) error
 }
 
-// NewPid create new initialized Capabilities object for given pid.
+// NewPid create new initialized Capabilities object for given pid when it
+// is nonzero, or for the current pid if pid is 0
 func NewPid(pid int) (Capabilities, error) {
 	return newPid(pid)
 }

--- a/capability/capability_linux.go
+++ b/capability/capability_linux.go
@@ -351,7 +351,15 @@ func (c *capsV3) Load() (err error) {
 		return
 	}
 
-	f, err := os.Open(fmt.Sprintf("/proc/%d/status", c.hdr.pid))
+	var status_path string
+
+	if c.hdr.pid == 0 {
+		status_path = fmt.Sprintf("/proc/self/status")
+	} else {
+		status_path = fmt.Sprintf("/proc/%d/status", c.hdr.pid)
+	}
+
+	f, err := os.Open(status_path)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
In this case we can use /proc/self/, which is correct even if a task
live in another pid namespace.

Signed-off-by: Andrey Vagin <avagin@openvz.org>