### PR TITLE
Don't use fmt.Fscanf for /proc/sys/kernel/cap_last_cap

### DIFF
--- a/capability/capability_linux.go
+++ b/capability/capability_linux.go
@@ -53,9 +53,15 @@ func initLastCap() error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
-	fmt.Fscanf(f, "%d", &capLastCap)
-	f.Close()
+	var b []byte = make([]byte, 11)
+	_, err = f.Read(b)
+	if err != nil {
+		return err
+	}
+
+	fmt.Sscanf(string(b), "%d", &capLastCap)
 
 	return nil
 }


### PR DESCRIPTION
fmt.Fscanf reads byte by byte from this file, but
this doesn't work for sysctl-s.

29279 open("/proc/sys/kernel/cap_last_cap", O_RDONLY|O_CLOEXEC
29279 <... open resumed> ) = 3
29279 read(3, "3", 1) = 1
29279 read(3, "", 1) = 0

Reported-by: @syndtr