### PR TITLE
Fix issue #12: break too early

### DIFF
--- a/capability/capability_linux.go
+++ b/capability/capability_linux.go
@@ -428,11 +428,11 @@ func (c *capsV3) Load() (err error) {
 		}
 		if strings.HasPrefix(line, "CapB") {
 			fmt.Sscanf(line[4:], "nd:  %08x%08x", &c.bounds[1], &c.bounds[0])
-			break
+			continue
 		}
 		if strings.HasPrefix(line, "CapA") {
 			fmt.Sscanf(line[4:], "mb:  %08x%08x", &c.ambient[1], &c.ambient[0])
-			break
+			continue
 		}
 	}
 	f.Close()


### PR DESCRIPTION
After getting CapBnd, Loop break too early,
can't to get CapAmb value.

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>