### PR TITLE
Fix capHeader.pid type

### DIFF
--- a/capability/capability_linux.go
+++ b/capability/capability_linux.go
@@ -103,12 +103,12 @@ func newPid(pid int) (c Capabilities, err error) {
 	case linuxCapVer1:
 		p := new(capsV1)
 		p.hdr.version = capVers
-		p.hdr.pid = pid
+		p.hdr.pid = int32(pid)
 		c = p
 	case linuxCapVer2, linuxCapVer3:
 		p := new(capsV3)
 		p.hdr.version = capVers
-		p.hdr.pid = pid
+		p.hdr.pid = int32(pid)
 		c = p
 	default:
 		err = errUnknownVers

--- a/capability/syscall_linux.go
+++ b/capability/syscall_linux.go
@@ -13,7 +13,7 @@ import (
 
 type capHeader struct {
 	version uint32
-	pid     int
+	pid     int32
 }
 
 type capData struct {


### PR DESCRIPTION
In C, int is 4 bytes in 32 and 64-bit systems. In Go, int is a
8 bytes in 64-bit systems. Before this fix, pid was being ignored
because the kernel will always read 0 due to padding added between
version and pid fields.