### PR TITLE
add CAP_PERFMON, CAP_BPF, and CAP_CHECKPOINT_RESTORE

### DIFF
--- a/capability/enum.go
+++ b/capability/enum.go
@@ -41,7 +41,9 @@ const (
 //go:generate go run enumgen/gen.go
 type Cap int
 
-// POSIX-draft defined capabilities.
+// POSIX-draft defined capabilities and Linux extensions.
+//
+// Defined in https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h
 const (
 	// In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
 	// overrides the restriction of changing file ownership and group
@@ -258,6 +260,18 @@ const (
 
 	// Allow reading audit messages from the kernel
 	CAP_AUDIT_READ = Cap(37)
+
+	// Allow system performance and observability privileged operations.
+	// Introduced in kernel 5.8.
+	CAP_PERFMON = Cap(38)
+
+	// Allow several BPF operations.
+	// Introduced in kernel 5.8.
+	CAP_BPF = Cap(39)
+
+	// Allow checkpoint/restore related operations.
+	// Introduced in kernel 5.9
+	CAP_CHECKPOINT_RESTORE = Cap(40)
 )
 
 var (

--- a/capability/enum_gen.go
+++ b/capability/enum_gen.go
@@ -80,6 +80,12 @@ func (c Cap) String() string {
 		return "block_suspend"
 	case CAP_AUDIT_READ:
 		return "audit_read"
+	case CAP_PERFMON:
+		return "perfmon"
+	case CAP_BPF:
+		return "bpf"
+	case CAP_CHECKPOINT_RESTORE:
+		return "checkpoint_restore"
 	}
 	return "unknown"
 }
@@ -125,5 +131,8 @@ func List() []Cap {
 		CAP_WAKE_ALARM,
 		CAP_BLOCK_SUSPEND,
 		CAP_AUDIT_READ,
+		CAP_PERFMON,
+		CAP_BPF,
+		CAP_CHECKPOINT_RESTORE,
 	}
 }


### PR DESCRIPTION
CAP_PERFMON and CAP_BPF were introduced in kernel 5.8: https://kernelnewbies.org/Linux_5.8#Introduce_CAP_BPF_and_CAP_PERFMON_security_capabilities

CAP_CHECKPOINT_RESTORE was merged on the master recently and will be available in the next version of the kernel. https://github.com/torvalds/linux/commit/124ea650d3072b005457faed69909221c2905a1f

The capability numbers are taken from https://github.com/torvalds/linux/blob/442489c219235991de86d0277b5d859ede6d8792/include/uapi/linux/capability.h#L373-L416
