### PR TITLE
capability: allow clearing individual capability sets

### DIFF
--- a/capability/capability.go
+++ b/capability/capability.go
@@ -39,9 +39,9 @@ type Capabilities interface {
 	Fill(kind CapType)
 
 	// Clear sets all bits of the given capabilities kind to zero. The
-	// 'kind' value should be one or combination (OR'ed) of CAPS,
-	// BOUNDS or AMBS.
-	Clear(kind CapType)
+	// 'which' value should be one or combination (OR'ed) of EFFECTIVE,
+	// PERMITTED, INHERITABLE, BOUNDING or AMBIENT.
+	Clear(which CapType)
 
 	// String return current capabilities state of the given capabilities
 	// set as string. The 'which' value should be one of EFFECTIVE,

--- a/capability/capability_linux.go
+++ b/capability/capability_linux.go
@@ -203,10 +203,14 @@ func (c *capsV1) Fill(kind CapType) {
 	}
 }
 
-func (c *capsV1) Clear(kind CapType) {
-	if kind&CAPS == CAPS {
+func (c *capsV1) Clear(which CapType) {
+	if which&EFFECTIVE != 0 {
 		c.data.effective = 0
+	}
+	if which&PERMITTED != 0 {
 		c.data.permitted = 0
+	}
+	if which&INHERITABLE != 0 {
 		c.data.inheritable = 0
 	}
 }
@@ -367,21 +371,24 @@ func (c *capsV3) Fill(kind CapType) {
 	}
 }
 
-func (c *capsV3) Clear(kind CapType) {
-	if kind&CAPS == CAPS {
+func (c *capsV3) Clear(which CapType) {
+	if which&EFFECTIVE != 0 {
 		c.data[0].effective = 0
-		c.data[0].permitted = 0
-		c.data[0].inheritable = 0
 		c.data[1].effective = 0
+	}
+	if which&PERMITTED != 0 {
+		c.data[0].permitted = 0
 		c.data[1].permitted = 0
+	}
+	if which&INHERITABLE != 0 {
+		c.data[0].inheritable = 0
 		c.data[1].inheritable = 0
 	}
-
-	if kind&BOUNDS == BOUNDS {
+	if which&BOUNDS == BOUNDS {
 		c.bounds[0] = 0
 		c.bounds[1] = 0
 	}
-	if kind&AMBS == AMBS {
+	if which&AMBS == AMBS {
 		c.ambient[0] = 0
 		c.ambient[1] = 0
 	}
@@ -609,14 +616,22 @@ func (c *capsFile) Fill(kind CapType) {
 	}
 }
 
-func (c *capsFile) Clear(kind CapType) {
-	if kind&CAPS == CAPS {
+func (c *capsFile) Clear(which CapType) {
+	if which&EFFECTIVE != 0 {
 		c.data.effective[0] = 0
-		c.data.data[0].permitted = 0
-		c.data.data[0].inheritable = 0
 		if c.data.version == 2 {
 			c.data.effective[1] = 0
+		}
+	}
+	if which&PERMITTED != 0 {
+		c.data.data[0].permitted = 0
+		if c.data.version == 2 {
 			c.data.data[1].permitted = 0
+		}
+	}
+	if which&INHERITABLE != 0 {
+		c.data.data[0].inheritable = 0
+		if c.data.version == 2 {
 			c.data.data[1].inheritable = 0
 		}
 	}

--- a/capability/capability_test.go
+++ b/capability/capability_test.go
@@ -79,5 +79,13 @@ func TestState(t *testing.T) {
 		testPartial(tc.name, tc.c, PERMITTED)
 		tc.c.Clear(CAPS | BOUNDS)
 		testEmpty(tc.name, tc.c, tc.sets)
+		tc.c.Fill(CAPS)
+		tc.c.Clear(EFFECTIVE)
+		if !tc.c.Empty(EFFECTIVE) {
+			t.Errorf("%s: Clear(EFFECTIVE) doesn't work", tc.name)
+		}
+		if tc.c.Empty(PERMITTED) {
+			t.Errorf("%s: Clear(EFFECTIVE) has effect on PERMITTED", tc.name)
+		}
 	}
 }


### PR DESCRIPTION
It's currently cumbersome to load the current capabilities,
and then drop all EFFECTIVE without touching PERMITTED. Allow
calling Clear with just EFFECTIVE, etc.