### PR TITLE
Ensure future compatibility, drop old code (v1/v2 support)

### DIFF
--- a/capability/capability_test.go
+++ b/capability/capability_test.go
@@ -51,7 +51,6 @@ func TestState(t *testing.T) {
 		sets CapType
 		max  Cap
 	}{
-		{"v1", new(capsV1), EFFECTIVE | PERMITTED, CAP_AUDIT_CONTROL},
 		{"v3", new(capsV3), EFFECTIVE | PERMITTED | BOUNDING, CAP_LAST_CAP},
 		{"file_v1", new(capsFile), EFFECTIVE | PERMITTED, CAP_AUDIT_CONTROL},
 		{"file_v2", capf, EFFECTIVE | PERMITTED, CAP_LAST_CAP},


### PR DESCRIPTION
This PR does two things.

1. Make sure that once (if ever) Linux kernel will start supporting capabilities v4, this library won't stop working. This relies on the assumption that v3 will still be supported.

2. Drops v1 and v2 API.

v3 API is used since the Linux kernel 2.6.26.

Since go 1.18 (no longer supported as of go 1.20 release), the minimum Linux kernel requirement is 2.6.32 (see [1]). So, it does not make sense to support capabilities v1 and v2 any more.

Drop the support.

[1] https://tip.golang.org/doc/go1.18#linux